### PR TITLE
Adds support for WooCommerce settings tabs

### DIFF
--- a/src/class-turbo-admin.js
+++ b/src/class-turbo-admin.js
@@ -256,6 +256,13 @@ export default class TurboAdmin {
                     'detectSelector': '#wp-admin-bar-my-sites #wp-admin-bar-my-sites-list .ab-submenu a',
                     'itemTitleFunction': (element) => "Sites: " + element.closest('.menupop').querySelector('a').innerText + ' - ' + element.innerText,
                     'itemUrlFunction': (element) => element.href
+                },
+                // WooCommerce Specific
+                {
+                    'detectType': 'dom',
+                    'detectSelector': '.woocommerce_page_wc-settings .woo-nav-tab-wrapper a.nav-tab',
+                    'itemTitleFunction': (element) => 'WooCommerce Settings: ' + element.textContent,
+                    'itemUrlFunction': (element) => element.href
                 }
             ]
         );


### PR DESCRIPTION
Just was experimenting and found I could add this pretty easily -- take it or leave it :)

It adds whatever tabs appear at the top of the WooCommerce settings page tabbed navigation to the palette under "WooCommerce Settings"

I was just fooling with with the `dist/main.min.js` file on my installation, so I haven't done any build with this, but it's tested working on my machine.